### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Installation
 
     mkdir -p ~/Library/texmf/tex/latex/local
     cd ~/Library/texmf/tex/latex/local
-    git clone git@github.com:alecjacobson/coloremoji.sty.git
+    git clone https://github.com/chardmeier/coloremoji.sty
     texhash coloremoji.sty
+    mktexlsr
 
 [Related blog entry](http://www.alecjacobson.com/weblog/?p=4018)
 


### PR DESCRIPTION
• clone command still referred to source repo, not this fork
• changed git to https protocol for anonymous clone
• added `mktexlsr` post-install, as ls-R database is likely need refresh to use this package.